### PR TITLE
Radarrapi

### DIFF
--- a/api.sh
+++ b/api.sh
@@ -11,7 +11,9 @@ source /config/movie-rename-script/.env
 
 escdir=$(printf '%q' "$1")
 if [[ "$fullpath" != /mnt/data* ]]; then
-    loc=$(printf "data\ndata2\ndata3" | fzf --header "Choose a directory in /mnt: ") # fzf selectbox, require /usr/bin/fzf to be installed `sudo apt install fzf -y`
+    loc=$(curl -fsSL --request GET --url ${RADARR_URL}/api/v3/rootfolder   --header "x-api-key: ${RADARR_API_KEY}" | jq -r '.[] | select(.path|test("data")) | (.path | split("/") | .[1]) as $name | ($name + "\t" + $name + " - " + ((.freeSpace/1024/1024/1024|floor/1000)|tostring) + " TB") ' | fzf --header "Choose a destination directory in /mnt: " | awk -F '\t' '{ print $1 }')
+    # request root folders from Radarr, print the free spaces in TB, use fzf to select the destination directory, and extract it using awk
+    # fzf selectbox, require /usr/bin/fzf to be installed `sudo apt install fzf -y`
     [[ ! -z $loc ]] || loc="data" # if destination is not set, defaults to /mnt/data
 fi
 

--- a/api.sh
+++ b/api.sh
@@ -5,32 +5,16 @@ find "$1" -iname "*.drc" -delete # drc is a marker file which could be created a
 find "$1" -name "*.ass" -delete
 find "$1" -name "*bad.srt" -delete
 fullpath=$1
+b64=$(printf %s "$1" | base64 -w0) # encode the path to handle special characters and spaces
 source /config/movie-rename-script/.env
 # source .env # if run locally
 
-# Create the JSON payload if file is in /mnt/data
-data=$(jq -n --arg path '"'"$fullpath"'"' '{"actionId": "Rename Movies", "arguments": [{"name": "location", "value": $path}]}')
-
-# If the file is not in /mnt/data (eg. it's on another drive), move it to /mnt/data/nzbget (temp dir for processing)
+escdir=$(printf '%q' "$1")
 if [[ "$fullpath" != /mnt/data* ]]; then
-    # Move the folder with progress into /mnt/data/nzbget
     loc=$(printf "data\ndata2\ndata3" | fzf --header "Choose a directory in /mnt: ") # fzf selectbox, require /usr/bin/fzf to be installed `sudo apt install fzf -y`
     [[ ! -z $loc ]] || loc="data" # if destination is not set, defaults to /mnt/data
-    touch -d "2 seconds ago" "$1"/* # update the modified time since these files are not modified by nzbget
-    basename=$(basename "$1") # define variables
-    set -e # exit script on rsync error
-    [ -f .fuse_hidden* ] && echo ".fusehidden found,\
- script will be stopped" && sleep 3 && exit 1 # exit script on .fuse_hidden files in dir
-    sleep 1 # add sleep timer so user can change to another folder before rsync deletes it
-    rsync -a --progress --remove-source-files "$1" "/mnt/$loc/nzbget/" || sleep 5
-    # rsync error will be printed if an error occured
-    rmdir "$1" # only remove folder if it's empty
-    set +e # script won't fail with error
-    # Olivetin processing of the files in nzbget folder, new JSON payload is created with the nzbget path
-    nzbpath="/mnt/$loc/nzbget/$basename"
-    # Create payload for nzbpath
-    newdata=$(jq -n --arg newpath '"'"$nzbpath"'"' '{"actionId": "Rename Movies", "arguments": [{"name": "location", "value": $newpath}]}')
-    curl -X POST "$OLIVETIN_URL/api/StartAction" -d "$newdata"
-else
-    curl -X POST "$OLIVETIN_URL/api/StartAction" -d "$data"
 fi
+
+ssh mediaserver  \
+    "cd ~/projects/movie-renamer; ./venv/bin/python main.py "$b64" "$loc";"
+

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 from moviefunc import *
+from moviefunc_radarr import query_queue
 import glob
 
 def onemkv():
@@ -20,6 +21,10 @@ if __name__ == "__main__":
             twomkv()
         if mkvcounter == 1:
             onemkv()
-        move(dir)
+        if dir.startswith("/mnt/nvme/share/scratch"):
+            query_queue(dir, dest_slug)
+        if dir.startswith("/mnt/data"):
+            # /mnt/data /mnt/data2 ... moves are instant
+            move(dir)
 
     

--- a/mkvmerge.sh
+++ b/mkvmerge.sh
@@ -99,13 +99,14 @@ else
   audio_track_idx="${audio_ids[*]}"
   en_ids=($(run_jq '[.tracks[]|select(.type=="subtitles" and ((.properties.language_ietf=="en") or (.properties.language=="eng")) and (.codec|test("HDMV")|not))]|.[].id'))
   zh_ids=($(run_jq '[.tracks[]|select(.type=="subtitles" and ((.properties.language_ietf=="zh") or (.properties.language=="chi")) and (.codec|test("HDMV")|not))]|.[].id'))
-  subtitle_track_idx="${en_ids[*]} ${zh_ids[*]}"
+  subtitle_track_idx="${en_ids[*]}${en_ids[*]:+ }${zh_ids[*]}"
 fi
 
 # --- Build command pieces ---------------------------------------
 ats=(--audio-tracks "$(join_by , $audio_track_idx)")
 sts=()
-[[ -n ${subtitle_track_idx:-} ]] && sts=(--subtitle-tracks "$(join_by , $subtitle_track_idx)")
+printf 'subtitle_track_idx=<%q>\n' "$subtitle_track_idx"
+[[ -n ${subtitle_track_idx} ]] && sts=(--subtitle-tracks "$(join_by , $subtitle_track_idx)")
 
 track_order_pre=(--track-order "0:0")
 audio_subtitle_opts=()
@@ -143,7 +144,7 @@ if [[ "$dir" != /mnt/data* ]]; then
     # Move the folder with progress into /mnt/data/nzbget
     loc=$(printf "data\ndata2\ndata3" | fzf --header "Choose a directory in /mnt: ") # fzf selectbox, require /usr/bin/fzf to be installed `sudo apt install fzf -y`
     [[ ! -z $loc ]] || loc="data" # if destination is not set, defaults to /mnt/data
-    touch -d "2 seconds ago" "$1"/* # update the modified time since these files are not modified by nzbget
+    find "$dir" -mindepth 1 -maxdepth 1 -exec touch -d '2 seconds ago' -- {} + # update the modified time since these files are not modified by nzbget
 fi
 
 # --- Execute -----------------------------------------------------
@@ -152,33 +153,26 @@ if (( DRY_RUN )); then
   exit 0
 fi
 
-read -p "Click any key to proceed with muxing..." d
-"${cmd[@]}"
-echo "✅ Mux complete: $mkvout"
-
-trap "echo -e '\nProcess interrupted, nothing deleted.'; exit 1" SIGINT SIGTERM
-sleep $SLEEP
-rm "$mkvfile"
-
-# Callback
-if [[ "$dir" != /mnt/data* ]]; then
-    basename=$(basename "$1") # define variables
-    set -e # exit script on rsync error
-    [ -f .fuse_hidden* ] && echo ".fusehidden found,\
- script will be stopped" && sleep 3 && exit 1 # exit script on .fuse_hidden files in dir
-    sleep 1 # add sleep timer so user can change to another folder before rsync deletes it
-    rsync -a --progress --remove-source-files "$1" "/mnt/$loc/nzbget/" || sleep 5
-    # rsync error will be printed if an error occured
-    rmdir "$1" # only remove folder if it's empty
-    set +e # script won't fail with error
-    # Olivetin processing of the files in nzbget folder, new JSON payload is created with the nzbget path
-    nzbpath="/mnt/$loc/nzbget/$basename"
-    # Create payload for nzbpath
-    newdata=$(jq -n --arg newpath '"'"$nzbpath"'"' '{"actionId": "Rename Movies", "arguments": [{"name": "location", "value": $newpath}]}')
-    echo $nzbpath
-    echo $OLIVETIN_URL
-    curl -X POST "$OLIVETIN_URL/api/StartAction" -d "$newdata"
+# Option to queue the command in a file for later execution or execute immediately
+read -p "Click any key to queue the command, click y to execute immediately..." d
+if [[ $d == "y" ]]; then
+  "${cmd[@]}"
+  echo "✅ Mux complete: $mkvout"
+  trap "echo -e '\nProcess interrupted, nothing deleted.'; exit 1" SIGINT SIGTERM
+  rm "$mkvfile"
+  # python script callback
+  $this_script_dir/venv/bin/python $this_script_dir/main.py "$dir" $loc
+  sleep $SLEEP
 else
-    curl -X POST "$OLIVETIN_URL/api/StartAction" -d "$data"
+  echo "Command queued for later execution:"
+  queued_file="/srv/scripts/radarr/mkvmerge_queue_$(date +%s)"
+  printf '%q ' "${cmd[@]}" > "$queued_file.queue" # line 1
+  echo -e >> "$queued_file.queue" # separator
+  echo $dir >> "$queued_file.queue"
+  echo $mkvfile >> "$queued_file.queue"
+  echo $loc >> "$queued_file.queue"
+  # rm "$mkvfile" will need to be handled separately
 fi
 
+
+# Callback

--- a/mkvmerge.sh
+++ b/mkvmerge.sh
@@ -85,7 +85,6 @@ if (( en_count>1 || zh_count>1 || ${#audio_ids[@]}>1 )); then
     fzf --multi --header "Select audio tracks" \
         --bind 'ctrl-a:select-all,ctrl-d:deselect-all' \
     | awk -F' :: ' '{print $4}')
-    echo $audio_track_idx
     [[ -z $audio_track_idx ]] && exit 1
     set +e
     subtitle_track_idx=$(run_jq '[.tracks[]|select(.type=="subtitles" and (.codec|test("HDMV")|not))] |
@@ -142,7 +141,7 @@ echo "---------------------------------------------------------------"
 # Snippet from api.sh
 if [[ "$dir" != /mnt/data* ]]; then
     # Move the folder with progress into /mnt/data/nzbget
-    loc=$(printf "data\ndata2\ndata3" | fzf --header "Choose a directory in /mnt: ") # fzf selectbox, require /usr/bin/fzf to be installed `sudo apt install fzf -y`
+    loc=$(curl -fsSL --request GET --url ${RADARR_URL}/api/v3/rootfolder   --header "x-api-key: ${RADARR_API_KEY}" | jq -r '.[] | select(.path|test("data")) | (.path | split("/") | .[1]) as $name | ($name + "\t" + $name + " - " + ((.freeSpace/1024/1024/1024|floor/1000)|tostring) + " TB") ' | fzf --header "Choose a destination directory in /mnt: " | awk -F '\t' '{ print $1 }') # same snippet from api.sh
     [[ ! -z $loc ]] || loc="data" # if destination is not set, defaults to /mnt/data
     find "$dir" -mindepth 1 -maxdepth 1 -exec touch -d '2 seconds ago' -- {} + # update the modified time since these files are not modified by nzbget
 fi

--- a/moviefunc.py
+++ b/moviefunc.py
@@ -10,15 +10,24 @@ import shutil
 from colorama import Fore, Back, Style
 import configparser
 import argparse
+import base64
 
 parser = argparse.ArgumentParser(description='Rename the movie directory and subtitle files.')
 parser.add_argument('directory', nargs='?', default='default', help='Directory to rename or change date')
+parser.add_argument('dest_slug', nargs='?', default='data', help='Destination slug for Radarr')
 directory = parser.parse_args().directory
+dest_slug = parser.parse_args().dest_slug
 
 if directory == 'default':
     dir = input('Enter the directory to rename or change date: ')
 else:
     dir = directory
+
+try:
+    # Accept base64 encoded directory for Bash script handling of edge cases
+    dir = base64.b64decode(dir).decode('utf-8')
+except Exception as e: # Normal strings will fail, so use original string
+    dir = dir
 
 basename = os.path.basename(dir)
 

--- a/moviefunc_radarr.py
+++ b/moviefunc_radarr.py
@@ -1,0 +1,49 @@
+import dotenv
+import os
+import json
+import time
+import requests
+import yaml
+
+dotenv.load_dotenv()
+
+RADARR_URL = os.getenv('RADARR_URL')
+RADARR_API_KEY = os.getenv('RADARR_API_KEY')
+YAML_OUTPUT_FOLDER = "/srv/scripts/radarr"
+
+def arr_request(path: str, method="GET", **kwargs):
+    url = f'{RADARR_URL}{path}'
+    headers = {'accept': 'application/json', 'X-Api-Key': RADARR_API_KEY}
+    if method == "POST":
+        response = requests.post(url, headers=headers, **kwargs)
+    elif method == "PUT":
+        response = requests.put(url, headers=headers, **kwargs)
+    else:
+        response = requests.get(url, headers=headers, **kwargs)
+    return response.json()
+
+def query_queue(filepath: str, dest_slug: str) -> None:
+    """
+    Create a YAML file in the output folder with the movie's Id qualityProfileId and a constructured destination path
+    Query the API for the movie based on filepath
+    YAML Output Example:
+    id: 689
+    qualityProfileId: 1
+    path: "/mnt/data/Movies/Movie (2014)"
+    """
+    # Replace the filepath because of Radarr path
+    # Only used when in the scratch folder
+    radarr_path = filepath.replace('/mnt/nvme/share/scratch','/ssd/scratch')
+    movies = arr_request('/api/v3/movie')
+    movie = next((movie for movie in movies if movie['path'] == radarr_path), None)
+    if movie is None:
+        print(f"Movie not found for path: {radarr_path}")
+        time.sleep(3) # for SpaceFM to not exit
+        return
+    output = {
+        'id': movie['id'],
+        'qualityProfileId': movie['qualityProfileId'],
+        'path': f"/{dest_slug}/Movies/{os.path.basename(filepath).rsplit('.', 1)[0]}"
+    }
+    with open(os.path.join(YAML_OUTPUT_FOLDER, f"{movie['id']}.yaml"), 'w') as yaml_file:
+        yaml.dump(output, yaml_file)

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -1,0 +1,61 @@
+"""
+Single Python file that checks the queue folder for MKVToolNix jobs, execute them, cleanup.
+Rename MKV and subtitle files with main.py and also handle Radarr move after MKVToolNix. Everything is done sequentially.
+This script is meant to be run automated in systemd timer at midnight.
+
+.queue file structure
+L1 Shell command to execute the MKVToolNix merge
+L2 Directory of the movie files (for main.py)
+L3 MKV file path (for deletion after merge)
+L4 Destination slug for Radarr data/data2 (for main.py)
+"""
+
+import os
+import subprocess
+import base64
+from pathlib import Path
+import yaml
+from radarr_move import move_movie
+
+SCRIPTS_FOLDER = "/srv/scripts/radarr"
+CURRENT_PATH = os.path.dirname(os.path.abspath(__file__))
+
+def process_mkvmerge(file_path: str) -> None:
+    with open(file_path, "r") as f:
+        content = f.read().splitlines()
+
+    content = [line for line in content if line.strip() != ""]  # Remove empty lines
+    shell_command, dir, mkvfile, dest_slug = content
+
+    print(f"Executing command: {shell_command}")
+
+    try:
+        subprocess.run(f"{shell_command}", shell=True, timeout=1200) # do not check since the error code might be 1 for success
+        clean_path = Path(dir)
+        subprocess.run(["sudo", "chown", "-R", "1000:1001", str(clean_path)], check=True) # MKVToolNix Docker shell don't follow UID GID
+        os.remove(mkvfile) # cleanup MKV file after merge
+        os.remove(file_path) # cleanup .queue task
+        # run python script directly
+        b64_dir = base64.b64encode(dir.encode('utf-8')).decode('utf-8')
+        subprocess.run(f"{CURRENT_PATH}/venv/bin/python {CURRENT_PATH}/main.py {b64_dir} {dest_slug}", shell=True, check=True)
+        # this process will create new .yaml file in the output folder for the Radarr move operation
+    except subprocess.CalledProcessError as e:
+        print(f"Command failed with error: {e}")
+    except subprocess.TimeoutExpired:
+        print("Command timed out.")
+
+if __name__ == "__main__":
+    # Process MKVToolNix merge tasks
+    queue_files = [f for f in os.listdir(SCRIPTS_FOLDER) if f.endswith('.queue')]
+    for file in queue_files:
+        file_path = os.path.join(SCRIPTS_FOLDER, file)
+        process_mkvmerge(file_path)
+    # Process Radarr move tasks
+    yaml_files = [f for f in os.listdir(SCRIPTS_FOLDER) if f.endswith('.yaml')]
+    for file in yaml_files:
+        file_path = os.path.join(SCRIPTS_FOLDER, file)
+        with open(file_path, 'r') as yaml_file:
+            yaml_data = yaml.safe_load(yaml_file)
+            print(f"Moving movie to {yaml_data['path']} with ID {yaml_data['id']}")
+            move_movie(yaml_data)
+        os.remove(file_path) # cleanup .yaml task after processing

--- a/radarr_move.py
+++ b/radarr_move.py
@@ -1,0 +1,30 @@
+from moviefunc_radarr import arr_request
+import threading
+import time
+
+def start_move(yaml_data: dict):
+    # mock yaml data for now
+    arr_request(f'/api/v3/movie/{yaml_data["id"]}?moveFiles=true', method="PUT", json=yaml_data)
+    status = None
+    while status != 'completed':
+        commands = arr_request('/api/v3/command')
+        command = next((cmd for cmd in commands if cmd['name'] == 'MoveMovie' and cmd['body']['destinationPath'] == yaml_data['path']), None)
+        if command:
+            status = command.get('status', 'unknown')
+            result = command.get('result', 'unknown')
+        time.sleep(5)
+    if result != 'successful':
+        raise Exception(f"Move failed with result: {result}")
+    print("Move completed successfully.")
+
+def move_movie(yaml_data: dict):
+    """
+    Threaded move operation with Timeout handling.
+    """
+    t = threading.Thread(target=start_move, args=(yaml_data,), daemon=True)
+    t.start()
+    t.join(timeout=600) # Wait for 10 minutes
+    if t.is_alive():
+        raise TimeoutError("Move operation is taking too long.")
+    else:
+        print("Move completed within the timeout period.")


### PR DESCRIPTION
The change uses Radarr API's move files function to ensure the movies are moved instead of running Rsync command. This allows the heavy disk IO operations to be queued at a later time, such as midnight where electricity is cheaper and prevent drive spindown. The system uses Radarr to download files always to a SSD first, the files can be accessed without waiting for drive to spinup and the access speed is fast. Additionally, running MKVMerge operations on it its significantly faster than using HDD.

The plan is to use YAML based human-readable file format with information about each Radarr API move request, each requests will be generated. Additionally to support MKVMerge preprocessing a .queue file system is used for any remux tasks before Radarr API. At midnight, a service consume all the queue file and YAML file.

Changes
- refactored `api.sh` the main entrypoint to use SSH instead of OliveTin API and execute Python command directly
- added queuing system in main Python script to queue the move 
- implemented base64 input in `moviefunc.py` to reduce issues with shell escaping
- refactored `mkvmerge.sh` to support queuing instead of running directly and improve fzf menu with free space remaining

Radarr API related work
- moviefunc_radarr.py - general functions for Radarr API request and queuing system
- radarr_move.py - functions for ingesting the YAML file moving files using the API
- orchestrator.py - callable in a systemd service, look for queue files of MKVMerge output and YAML file of move requests and process it sequentially